### PR TITLE
double cpu and memory for ui on k8s cluster

### DIFF
--- a/helm/ffc-sfd-experiment-ui/templates/ingress.yaml
+++ b/helm/ffc-sfd-experiment-ui/templates/ingress.yaml
@@ -1,3 +1,23 @@
 {{- include "ffc-helm-library.azure-ingress" (list . "ffc-sfd-experiment-ui.ingress") -}}
   {{- define "ffc-sfd-experiment-ui.ingress" -}}
-  {{- end -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: {{ .Values.ingress.class }}
+  rules:
+    - host: {{ .Values.ingress.server }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.ingress.endpoint }}
+                port:
+                  number: 80
+{{- end -}}

--- a/helm/ffc-sfd-experiment-ui/values.yaml
+++ b/helm/ffc-sfd-experiment-ui/values.yaml
@@ -21,10 +21,10 @@ containerSecret:
 deployment: {}
 
 container:
-  requestMemory: 100Mi
-  requestCpu: 100m
-  limitMemory: 100Mi
-  limitCpu: 100m
+  requestMemory: 200Mi
+  requestCpu: 200m
+  limitMemory: 200Mi
+  limitCpu: 200m
   port: 3600
 
 livenessProbe:
@@ -54,4 +54,4 @@ experimentApi:
 ingress:
   class: nginx
   endpoint: ffc-sfd-experiment-ui
-  server: value.replaced.from.app.config
+  server: rps-experiment


### PR DESCRIPTION
The sandpit resources for our UI appears quite stretched at time.
This PR doubles the available memory and CPU capacity to accomodate this.
```
$ k top node aks-agentpool-14654183-vmss0000a9
NAME CPU(cores)                         | CPU%    | MEMORY(bytes) | MEMORY%
aks-agentpool-14654183-vmss0000a9 1335m | 70%     | 6446Mi        | 141%
```