### PR TITLE
double cpu and memory for ui on k8s cluster

### DIFF
--- a/helm/ffc-sfd-experiment-ui/values.yaml
+++ b/helm/ffc-sfd-experiment-ui/values.yaml
@@ -21,10 +21,10 @@ containerSecret:
 deployment: {}
 
 container:
-  requestMemory: 100Mi
-  requestCpu: 100m
-  limitMemory: 100Mi
-  limitCpu: 100m
+  requestMemory: 200Mi
+  requestCpu: 200m
+  limitMemory: 200Mi
+  limitCpu: 200m
   port: 3600
 
 livenessProbe:
@@ -54,4 +54,4 @@ experimentApi:
 ingress:
   class: nginx
   endpoint: ffc-sfd-experiment-ui
-  server: value.replaced.from.app.config
+  server: rps-experiment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-sfd-experiment-ui",
-  "version": "1.12.3",
+  "version": "1.12.5",
   "description": "Web frontend for PoC future RPS",
   "homepage": "https://github.com/DEFRA/ffc-sfd-experiment-ui",
   "main": "app/index.js",


### PR DESCRIPTION
The sandpit resources for our UI appears quite stretched at time.
Here is a `node top` snapshot taken at a time when the UI was inaccessible (at one point the CPU was at 99% too) ~
```
$ k top node aks-agentpool-14654183-vmss0000a9
NAME CPU(cores)                         | CPU%    | MEMORY(bytes) | MEMORY%
aks-agentpool-14654183-vmss0000a9 1335m | 70%     | 6446Mi        | 141%
```
This PR doubles the available memory and CPU capacity to accomodate this.