### PR TITLE
increase to timeouts on liveness/readiness probe

### DIFF
--- a/helm/ffc-sfd-experiment-ui/values.yaml
+++ b/helm/ffc-sfd-experiment-ui/values.yaml
@@ -30,18 +30,18 @@ container:
 livenessProbe:
   path: /healthz
   port: 3600
-  initialDelaySeconds: 20
-  periodSeconds: 10
-  failureThreshold: 3
-  timeoutSeconds: 5
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  failureThreshold: 15
+  timeoutSeconds: 10
 
 readinessProbe:
   path: /healthy
   port: 3600
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  failureThreshold: 3
-  timeoutSeconds: 5
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  failureThreshold: 15
+  timeoutSeconds: 10
 
 cache:
   host: your-cache-host

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-sfd-experiment-ui",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "Web frontend for PoC future RPS",
   "homepage": "https://github.com/DEFRA/ffc-sfd-experiment-ui",
   "main": "app/index.js",


### PR DESCRIPTION
The events log shows that the ui on the sandpit is having multiple liveness probe failures, leading to pod restarts.
I've increased the timeouts to accomodate.