### PR TITLE
further increase to readiness/liveness timeouts w slight increase in resources

### DIFF
--- a/helm/ffc-sfd-experiment-ui/values.yaml
+++ b/helm/ffc-sfd-experiment-ui/values.yaml
@@ -21,27 +21,27 @@ containerSecret:
 deployment: {}
 
 container:
-  requestMemory: 200Mi
-  requestCpu: 200m
-  limitMemory: 200Mi
+  requestMemory: 300Mi
+  requestCpu: 300m
+  limitMemory: 300Mi
   limitCpu: 200m
   port: 3600
 
 livenessProbe:
   path: /healthz
   port: 3600
-  initialDelaySeconds: 60
-  periodSeconds: 20
-  failureThreshold: 15
-  timeoutSeconds: 10
+  initialDelaySeconds: 120
+  periodSeconds: 40
+  failureThreshold: 30
+  timeoutSeconds: 20
 
 readinessProbe:
   path: /healthy
   port: 3600
-  initialDelaySeconds: 60
-  periodSeconds: 20
-  failureThreshold: 15
-  timeoutSeconds: 10
+  initialDelaySeconds: 120
+  periodSeconds: 40
+  failureThreshold: 30
+  timeoutSeconds: 20
 
 cache:
   host: your-cache-host

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-sfd-experiment-ui",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "Web frontend for PoC future RPS",
   "homepage": "https://github.com/DEFRA/ffc-sfd-experiment-ui",
   "main": "app/index.js",


### PR DESCRIPTION
more time required on readiness probe -

` Warning   Unhealthy           pod/ffc-sfd-experiment-ui-69b4575f55-qt29d    Readiness probe failed: Get "http://10.244.3.219:3600/healthy": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`