### PR TITLE
fixes the radio IDs on the parcel select screen

### DIFF
--- a/app/routes/choose-land-parcel.js
+++ b/app/routes/choose-land-parcel.js
@@ -22,6 +22,7 @@ const createModel = (rawLandParcels, selectedLandParcel, errMessage) => {
       return {
         text: `${lp.sheetId} ${lp.id} (${parseFloat(lp.area).toFixed(4)} ha)`,
         hint: listFeatures(lp.features),
+        id: `${lp.sheetId}${lp.id}`,
         value: JSON.stringify({
           id: lp.id,
           area: lp.area,


### PR DESCRIPTION
The Radio IDs are now unique identifiers of sheetID + parcelID

For example: `SX68386599`